### PR TITLE
Use new Routing from Go 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shaksiper/gorss
 
-go 1.21.8
+go 1.22.1
 
 require (
 	github.com/go-chi/chi/v5 v5.0.12

--- a/handler_feed_follow.go
+++ b/handler_feed_follow.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
 	"github.com/shaksiper/gorss/internal/database"
 )
@@ -51,10 +50,10 @@ func (apiCfg *apiConfig) handlerGetFeedFollowed(writer http.ResponseWriter, requ
 }
 
 func (apiCfg *apiConfig) handlerDeleteFeedFollowed(writer http.ResponseWriter, request *http.Request, user database.User) {
-	feedFollowedIDRaw := chi.URLParam(request, "feedFollowedID")
+	feedFollowedIDRaw := request.PathValue("feedFollowID")
 	feedFollowedID, err := uuid.Parse(feedFollowedIDRaw)
 	if err != nil {
-		respondWithError(writer, 400, fmt.Sprintf("Could not parse feed ID (%s): %v", user.ID, err))
+		respondWithError(writer, 400, fmt.Sprintf("Could not parse feed ID (%s): %v", feedFollowedID, err))
 		return
 	}
 	// TODO: make this return deleated feed info

--- a/scraper.go
+++ b/scraper.go
@@ -46,7 +46,7 @@ func scrapeFeed(db *database.Queries, wg *sync.WaitGroup, feed database.Feed) RS
 
 	rssFeed, err := urlToFeed(feed.Url)
 	if err != nil {
-		log.Fatalf("Error: fetching feed [%v] failed: %v", feed.ID, err)
+		log.Printf("Error: fetching feed [%v] failed: %v", feed.ID, err)
 		return RSSFeed{}
 	}
 
@@ -79,7 +79,7 @@ func scrapeFeed(db *database.Queries, wg *sync.WaitGroup, feed database.Feed) RS
 			if strings.Contains(err.Error(), "duplicate key") {
 				continue
 			}
-			log.Fatalf("Could not create post for %v: %v", feed.ID, err)
+			log.Printf("Could not create post for %v: %v", feed.ID, err)
 		}
 	}
 


### PR DESCRIPTION
With new routing introduced in Go 1.22, chi routing dependency is no longer needed.